### PR TITLE
Allow updating lockdown multiplier parameters

### DIFF
--- a/src/COVID19/model.py
+++ b/src/COVID19/model.py
@@ -35,7 +35,10 @@ PYTHON_SAFE_UPDATE_PARAMS = [
     "lockdown_on",
     "app_turned_on",
     "app_users_fraction",
-    "trace_on_symptoms"
+    "trace_on_symptoms",
+    "lockdown_house_interaction_multiplier",
+    "lockdown_random_network_multiplier",
+    "lockdown_work_network_multiplier",
 ]
 
 class EVENT_TYPES(enum.Enum):

--- a/src/params.c
+++ b/src/params.c
@@ -199,6 +199,33 @@ int get_model_param_lockdown_on(model *model)
 }
 
 /*****************************************************************************************
+*  Name:        get_model_param_lockdown_house_interaction_multiplier
+*  Description: Gets the value of a double parameter
+******************************************************************************************/
+double get_model_param_lockdown_house_interaction_multiplier(model *model)
+{
+	return model->params->lockdown_house_interaction_multiplier;
+}
+
+/*****************************************************************************************
+*  Name:        get_model_param_lockdown_random_network_multiplier
+*  Description: Gets the value of a double parameter
+******************************************************************************************/
+double get_model_param_lockdown_random_network_multiplier(model *model)
+{
+	return model->params->lockdown_random_network_multiplier;
+}
+
+/*****************************************************************************************
+*  Name:        get_model_param_lockdown_work_network_multiplier
+*  Description: Gets the value of a double parameter
+******************************************************************************************/
+double get_model_param_lockdown_work_network_multiplier(model *model)
+{
+	return model->params->lockdown_work_network_multiplier;
+}
+
+/*****************************************************************************************
 *  Name:        set_model_param_quarantine_days
 *  Description: Sets the value of parameter
 ******************************************************************************************/
@@ -458,6 +485,57 @@ int set_model_param_lockdown_elderly_on( model *model, int value )
 		if( indiv->age_type == AGE_TYPE_ELDERLY )
 			update_random_interactions( indiv, params );
 	}
+
+	return TRUE;
+}
+
+/*****************************************************************************************
+*  Name:        set_model_param_lockdown_house_interaction_multiplier
+*  Description: Sets the value of parameter
+******************************************************************************************/
+int set_model_param_lockdown_house_interaction_multiplier( model *model, double value )
+{
+	model->params->lockdown_house_interaction_multiplier = value;
+
+	if( model->params->lockdown_on )
+		return set_model_param_lockdown_on( model, TRUE );
+
+	if( model->params->lockdown_elderly_on )
+		return set_model_param_lockdown_elderly_on( model, TRUE );
+
+	return TRUE;
+}
+
+/*****************************************************************************************
+*  Name:        set_model_param_lockdown_random_network_multiplier
+*  Description: Sets the value of parameter
+******************************************************************************************/
+int set_model_param_lockdown_random_network_multiplier( model *model, double value )
+{
+	model->params->lockdown_random_network_multiplier = value;
+
+	if( model->params->lockdown_on )
+		return set_model_param_lockdown_on( model, TRUE );
+
+	if( model->params->lockdown_elderly_on )
+		return set_model_param_lockdown_elderly_on( model, TRUE );
+
+	return TRUE;
+}
+
+/*****************************************************************************************
+*  Name:        set_model_param_lockdown_work_network_multiplier
+*  Description: Sets the value of parameter
+******************************************************************************************/
+int set_model_param_lockdown_work_network_multiplier( model *model, double value )
+{
+	model->params->lockdown_work_network_multiplier = value;
+
+	if( model->params->lockdown_on )
+		return set_model_param_lockdown_on( model, TRUE );
+
+	if( model->params->lockdown_elderly_on )
+		return set_model_param_lockdown_elderly_on( model, TRUE );
 
 	return TRUE;
 }

--- a/src/params.c
+++ b/src/params.c
@@ -395,6 +395,9 @@ int set_model_param_lockdown_on( model *model, int value )
 	else
 	if( value == FALSE )
 	{
+		if( !params->lockdown_on )
+			return TRUE;
+
 		for( network = 0; network < N_WORK_NETWORKS; network++ )
 			if( !( NETWORK_TYPE_MAP[ network ] == NETWORK_TYPE_ELDERLY && params->lockdown_elderly_on ) )
 				params->daily_fraction_work_used[network] = params->daily_fraction_work;
@@ -434,6 +437,9 @@ int set_model_param_lockdown_elderly_on( model *model, int value )
 	else
 	if( value == FALSE )
 	{
+		if( !params->lockdown_elderly_on )
+			return TRUE;
+
 		if( !params->lockdown_on )
 		{
 			for( network = 0; network < N_WORK_NETWORKS; network++ )

--- a/src/params.h
+++ b/src/params.h
@@ -164,6 +164,9 @@ int get_model_param_test_order_wait(model *model);
 double get_model_param_app_users_fraction(model *model);
 int get_model_param_app_turned_on(model *model);
 int get_model_param_lockdown_on(model *model);
+double get_model_param_lockdown_house_interaction_multiplier(model *model);
+double get_model_param_lockdown_random_network_multiplier(model *model);
+double get_model_param_lockdown_work_network_multiplier(model *model);
 
 int set_model_param_quarantine_days(model *model, int value);
 int set_model_param_self_quarantine_fraction(model *model, double value);
@@ -183,6 +186,9 @@ int set_model_param_test_order_wait(model *model, int value);
 int set_model_param_app_users_fraction(model *model, double value);
 int set_model_param_app_turned_on(model *model, int value);
 int set_model_param_lockdown_on(model *model, int value);
+int set_model_param_lockdown_house_interaction_multiplier(model *model, double value);
+int set_model_param_lockdown_random_network_multiplier(model *model, double value);
+int set_model_param_lockdown_work_network_multiplier(model *model, double value);
 int set_model_param_lockdown_elderly_on(model *model, int value);
 
 void check_params( parameters* );

--- a/tests/test_python_c_interface.py
+++ b/tests/test_python_c_interface.py
@@ -19,6 +19,7 @@ import pandas as pd
 from random import randrange
 
 sys.path.append("src/COVID19")
+import covid19
 from parameters import ParameterSet
 from model import Model, Parameters, ModelParameterException, AgeGroupEnum
 
@@ -175,3 +176,36 @@ class TestClass(object):
         for age in AgeGroupEnum:
             assert res.get(f"total_infected{age.name}", None) is not None, f"Could not get total_infected{age.name}"
         assert res.get("total_infected") == sum([res.get(f"total_infected{age.name}") for age in AgeGroupEnum]), "Total infected does not equal sum of age groups"
+
+    def test_set_lockdown_multiplier_params(self):
+        params = Parameters(
+            constant.TEST_DATA_TEMPLATE,
+            constant.PARAM_LINE_NUMBER,
+            constant.DATA_DIR_TEST,
+            constant.TEST_HOUSEHOLD_FILE,
+        )
+        model = Model(params)
+        assert covid19.get_param_lockdown_on(model.c_params) == 0
+
+        model.update_running_params("lockdown_work_network_multiplier", 0.4)
+        assert model.get_param("lockdown_work_network_multiplier") == 0.4
+
+        model.update_running_params("lockdown_random_network_multiplier", 0.8)
+        assert model.get_param("lockdown_random_network_multiplier") == 0.8
+
+        model.update_running_params("lockdown_house_interaction_multiplier", 1.2)
+        assert model.get_param("lockdown_house_interaction_multiplier") == 1.2
+
+        model.update_running_params("lockdown_on", 1)
+        assert covid19.get_param_lockdown_on(model.c_params) == 1
+
+        model.update_running_params("lockdown_work_network_multiplier", 0.5)
+        assert model.get_param("lockdown_work_network_multiplier") == 0.5
+
+        model.update_running_params("lockdown_random_network_multiplier", 0.9)
+        assert model.get_param("lockdown_random_network_multiplier") == 0.9
+
+        model.update_running_params("lockdown_house_interaction_multiplier", 1.3)
+        assert model.get_param("lockdown_house_interaction_multiplier") == 1.3
+
+        assert covid19.get_param_lockdown_on(model.c_params) == 1


### PR DESCRIPTION
`lockdown_house_interaction_multiplier`, `lockdown_random_network_multiplier`, and `lockdown_work_network_multiplier` can now be updated whilst the model is running. This allows modelling evolving lockdown conditions.