### PR TITLE
Bug fix - removal of sub-critical trace tokens  - index list is now double

### DIFF
--- a/src/interventions.c
+++ b/src/interventions.c
@@ -278,6 +278,8 @@ void remove_traced_on_this_trace( model *model, individual *indiv )
 		if( contact->traced_on_this_trace < 1 )
 		{
 			token->next_index = next_token->next_index;
+			if( token->next_index != NULL )
+				token->next_index->last_index = token;
 			remove_one_trace_token( model, next_token );
 		}
 		else
@@ -629,7 +631,7 @@ void intervention_quarantine_household(
 
 /*****************************************************************************************
 *  Name:		intervention_quarantine_household_of_traced
-*  Description: Quarantineteh household mebmers of everyone on a trace list
+*  Description: Quarantine household members of everyone on a trace list
 *  Returns:		void
 ******************************************************************************************/
 void intervention_quarantine_household_of_traced(


### PR DESCRIPTION
When the risk score is sub-critical for an individual on a trace, we remove the trace token at the end of the trace. Now that we have switched to trace tokens being doubly linked on the index, we need to replace the back link as well on this removal.