### PR TITLE
Fix errors in Makefile when uninstalling

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,12 +33,12 @@ make all
 To install the Python interface, first install [SWIG](http://www.swig.org/), then:
 
 ```bash
-make swig-all
+make install
 ```
 
 For developers, the following installs the Python interface inplace, so modifications to the code are applied without needing to reinstall
 ```bash
-make swig-develop
+make dev
 ```
 
 Usage

--- a/examples/example_run_simulation_with_lockdown.py
+++ b/examples/example_run_simulation_with_lockdown.py
@@ -10,7 +10,6 @@ and then runs for 50 days, after 50 days lock down is turned on
 from COVID19.model import Parameters, Model, OccupationNetworkEnum
 import json
 from pathlib import Path
-import covid19
 from random import randint
 from tqdm import trange
 from typing import Dict, Any

--- a/src/Makefile
+++ b/src/Makefile
@@ -28,26 +28,25 @@ LIB = /usr/local/lib
 CFLAGS = -g -Wall -fmessage-length=0 -I$(INC) -O0
 
 # Swig's output
-SWIG_OUTPUT = covid19_wrap.o covid19_wrap.c covid19.py _covid19.cpython-37m-darwin.so build
+SWIG_OUTPUT = covid19_wrap.o covid19_wrap.c covid19.py _covid19.cpython-37m-darwin.so build covid19.egg-info
 
 # To compile
-swig-all:
-	# swig -outdir COVID19 -python covid19.i
+install: $(OBJS)
+install: all;
 	swig -python covid19.i
-	# python3 setup.py build_ext --inplace
 	$(PYTHON) -m pip install $(PIP_FLAGS) .
 
-swig-develop: PIP_FLAGS += -e
-swig-develop: swig-all;
+dev: PIP_FLAGS += -e
+dev: install;
 
 all: $(OBJS)
 	$(C) -L$(LIB) -o $(EXE) $(OBJS) $(LFLAGS)
 
 clean:
-	rm -rf $(OBJS) $(EXE) $(SWIG_OUTPUT)
 	$(PYTHON) -m pip uninstall -y covid19
+	rm -rf $(OBJS) $(EXE) $(SWIG_OUTPUT)
 
 .c.o:
 	$(C) $(CFLAGS) -c $< -o $@
 
-.PHONY: swig-all swig-develop all clean
+.PHONY: install dev all clean

--- a/src/model_utils.i
+++ b/src/model_utils.i
@@ -1,7 +1,5 @@
 %module model_utils
 
-#include "model.h"
-
 %inline %{
 int utils_n_current( model *model, int type ) {
     return model->event_lists[type].n_current;

--- a/tests/Dockerfile
+++ b/tests/Dockerfile
@@ -19,7 +19,7 @@ RUN python3 -m pip install -r /requirements.txt
 COPY . /OpenABM-Covid19
 
 WORKDIR /OpenABM-Covid19
-RUN cd src && make && make all && make
+RUN cd src && make clean && make install
 
 WORKDIR /OpenABM-Covid19
 ENTRYPOINT ["/usr/local/bin/pytest", "-s"]

--- a/tests/test_python_c_interface.py
+++ b/tests/test_python_c_interface.py
@@ -95,7 +95,6 @@ class TestClass(object):
         params.set_param( "app_users_fraction", 0.25)
         model = Model(params)
 
-        STEPS = 2
         # Run steps
         for step in range(0, STEPS):
             model.one_time_step()


### PR DESCRIPTION
When installing in dev mode the covid19.eggfile was not being removed so
uninstalling the module after this failed.

Put everything in one compilation step so we make sure both the C code
and Python module are being created correctly everytime we compile.

Dockerfile was calling make multiple times