### PR TITLE
Handle edge cases from multiple tracing of same individual

### DIFF
--- a/src/interventions.c
+++ b/src/interventions.c
@@ -166,6 +166,7 @@ trace_token* new_trace_token( model *model, individual *indiv, int contact_time 
 	token->last_index = NULL;
 	token->individual = indiv;
 	token->contact_time = contact_time;
+	token->index_status = UNKNOWN;
 	model->n_trace_tokens_used++;
 
 	if( model->n_trace_tokens == model->n_trace_tokens_used)
@@ -366,6 +367,7 @@ int intervention_quarantine_until(
 	{
 		// add the trace token to their list
 		trace_token *token = new_trace_token( model, indiv, contact_time );
+		token->index_status = index_token->index_status;
 
 		if( indiv->trace_tokens != NULL )
 		{
@@ -627,7 +629,7 @@ void intervention_quarantine_household(
 		{
 			contact = &(model->population[members[idx]]);
 
-			if( contact->status == DEATH || is_in_hospital( contact ) )
+			if( contact->status == DEATH || is_in_hospital( contact ) || contact->infection_events->is_case )
 				continue;
 
 			intervention_quarantine_until( model, contact, time_event, TRUE, index_token, contact_time, risk_scores[ contact->age_group ] );
@@ -699,19 +701,24 @@ void intervention_index_case_symptoms_to_positive(
 
  		if( contact->traced_on_this_trace == FALSE )
  		{
-			if( gsl_ran_bernoulli( rng, params->quarantine_compliance_traced_positive  ) )
-			{
-				contact_time    = token->contact_time;
-				time_quarantine = contact_time + sample_transition_time( model, TRACED_QUARANTINE_POSITIVE );
-				intervention_quarantine_until( model, contact, time_quarantine, TRUE, NULL, contact_time, 1 );
-			}
-			contact->traced_on_this_trace = TRUE;
+ 			if( contact->status != DEATH && !is_in_hospital( contact ) && !contact->infection_events->is_case )
+ 			{
+				if( gsl_ran_bernoulli( rng, params->quarantine_compliance_traced_positive  ) )
+				{
+					contact_time    = token->contact_time;
+					time_quarantine = contact_time + sample_transition_time( model, TRACED_QUARANTINE_POSITIVE );
 
-			if( trace_household & ( contact->house_no != house_no ) & ( contact->quarantine_release_event != NULL ) )
-			{
-				time_quarantine = contact->quarantine_release_event->time;
-				intervention_quarantine_household( model, contact, time_quarantine, FALSE, index_token, FALSE );
-			}
+					intervention_quarantine_until( model, contact, time_quarantine, TRUE, NULL, contact_time, 1 );
+				}
+
+				if( trace_household & ( contact->house_no != house_no ) & ( contact->quarantine_release_event != NULL ) )
+				{
+					time_quarantine = contact->quarantine_release_event->time;
+
+					intervention_quarantine_household( model, contact, time_quarantine, FALSE, index_token, FALSE );
+				}
+ 			}
+			contact->traced_on_this_trace = TRUE;
  		}
 	}
 }
@@ -730,6 +737,9 @@ void intervention_index_case_symptoms_to_positive(
 void intervention_on_symptoms( model *model, individual *indiv )
 {
 	if( !model->params->interventions_on )
+		return;
+
+	if( indiv->index_trace_token != NULL )
 		return;
 
 	int quarantine, time_event;
@@ -777,10 +787,13 @@ void intervention_on_hospitalised( model *model, individual *indiv )
 	if( !model->params->interventions_on )
 		return;
 
-	intervention_test_order( model, indiv, model->time );
+	if( indiv->quarantine_test_result == NO_TEST && !indiv->infection_events->is_case )
+	{
+		intervention_test_order( model, indiv, model->time );
 
-	if( model->params->allow_clinical_diagnosis )
-		intervention_on_positive_result( model, indiv );
+		if( model->params->allow_clinical_diagnosis )
+			intervention_on_positive_result( model, indiv );
+	}
 }
 
 /*****************************************************************************************
@@ -805,7 +818,7 @@ void intervention_on_positive_result( model *model, individual *indiv )
 
 	if( !is_in_hospital( indiv ) )
 	{
-		time_event = model->time + sample_transition_time( model, TEST_RESULT_QUARANTINE );
+		time_event = index_token->contact_time + sample_transition_time( model, TEST_RESULT_QUARANTINE );
 		intervention_quarantine_until( model, indiv, time_event, TRUE, NULL, model->time, 1 );
 	}
 	indiv->traced_on_this_trace = TRUE;


### PR DESCRIPTION
Don't convert an amber->red if traced contact has become a case or is in
hospital

When hospitalised don't order a test if currently waiting for a test
result OR is currently a confirmed case

On a positive result, calculate quarantine time from when first became
an index

Don't trace on symptoms if current an index case (due to non-covid
symptoms)

When quarantining households don't quarantine members who are already
cases

Add index_Status to new token

In tests on whether household members are quarantined, remove those who
are already cases