### PR TITLE
Remove old swig-all

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,7 @@ def compile_covid_ibm(request):
     shutil.copytree(constant.IBM_DIR, constant.IBM_DIR_TEST)
 
     # Construct the compilation command and compile
-    compile_command = "make clean; make all; make swig-all"
+    compile_command = "make clean; make install"
     completed_compilation = subprocess.run(
         [compile_command], shell = True, cwd = constant.IBM_DIR_TEST, capture_output = True
     )


### PR DESCRIPTION
```
➜  OpenABM-Covid19 (remove-swig-all) ✗ pytest tests
================================================ test session starts =================================================
platform darwin -- Python 3.7.7, pytest-5.4.1, py-1.8.1, pluggy-0.13.1
rootdir: /Users/daniel.montero@ibm.com/covid19/OpenABM-Covid19
plugins: repeat-0.8.0
collected 155 items

tests/test_demographics.py .........                                                                           [  5%]
tests/test_disease_dynamics.py ................                                                                [ 16%]
tests/test_file_concordance.py .......                                                                         [ 20%]
tests/test_ibm.py ..........                                                                                   [ 27%]
tests/test_infection_dynamics.py ..........................F                                                   [ 44%]
tests/test_interventions.py ........F.F.FFFFFFFFFF                                                             [ 58%]
tests/test_network.py .........................FFF                                                             [ 76%]
tests/test_python_c_interface.py %
```