### PR TITLE
Fix warnings in tests for adapter_covid19

### DIFF
--- a/src/adapter_covid19/corporate_bankruptcy.py
+++ b/src/adapter_covid19/corporate_bankruptcy.py
@@ -254,12 +254,16 @@ class CorporateBankruptcyModel(BaseCorporateBankruptcyModel):
     def _normed_vector(self, vector: np.array):
         """
         Compute normed vector (unit vector)
+        Special case if zero vector: returns zero vector
 
         Parameters
         ----------
         vector: numeric vector to be normed
         """
-        return vector / np.sum(vector)
+        abs_sum = np.abs(vector).sum()
+        if abs_sum == 0:
+            return vector
+        return vector / abs_sum
 
     def _simplex_draw(self, n: int):
         """
@@ -355,9 +359,12 @@ class CorporateBankruptcyModel(BaseCorporateBankruptcyModel):
 
         total_solvent_days = solvent_days.sum()
 
-        corp_cash_buffer = np.array(
-            [days / total_solvent_days * cash_buffer for days in solvent_days]
-        )
+        if total_solvent_days == 0:
+            corp_cash_buffer = np.zeros(size)
+        else:
+            corp_cash_buffer = np.array(
+                [days / total_solvent_days * cash_buffer for days in solvent_days]
+            )
         return corp_cash_buffer
 
     def _get_mean_cash_buffer_days(
@@ -618,6 +625,8 @@ class CorporateBankruptcyModel(BaseCorporateBankruptcyModel):
                 * (self.solvent_bool[BusinessSize.large][s])
             )
             / DAYS_IN_A_YEAR
+            if self.solvent_bool[BusinessSize.large][s].sum() != 0
+            else 0
             for s in Sector
         }
         sme_cash_outgoing = {
@@ -631,6 +640,8 @@ class CorporateBankruptcyModel(BaseCorporateBankruptcyModel):
                 * (self.solvent_bool[BusinessSize.sme][s])
             )
             / DAYS_IN_A_YEAR
+            if self.solvent_bool[BusinessSize.sme][s].sum() != 0
+            else 0
             for s in Sector
         }
 

--- a/src/adapter_covid19/gdp.py
+++ b/src/adapter_covid19/gdp.py
@@ -2,12 +2,13 @@ import abc
 import copy
 import itertools
 import logging
+import warnings
 from dataclasses import dataclass
 from typing import Tuple, Mapping, Sequence, Optional, Union, List
 
 import numpy as np
 import pandas as pd
-from scipy.optimize import linprog, OptimizeResult
+from scipy.optimize import linprog, OptimizeResult, OptimizeWarning
 
 from adapter_covid19.constants import START_OF_TIME, DAYS_IN_A_YEAR
 from adapter_covid19.data_structures import (
@@ -36,6 +37,15 @@ from adapter_covid19.enums import (
     WorkerStateConditional,
 )
 
+# Sometimes we pass in a non-full-rank matrix into a linear program
+# optimiser and a warning gets raised as a result. This is fine -
+# it only has a slight computational cost penalty, and because of the
+# complexity in setting up the linear program, it is uncertain as to
+# whether the formulation of the LP to ensure full rank would be more
+# performant than just passing a non-full rank matrix in.
+warnings.filterwarnings(
+    action="ignore", category=OptimizeWarning, module=__name__,
+)
 LOGGER = logging.getLogger(__name__)
 
 

--- a/tests/adapter_covid19/test_economics.py
+++ b/tests/adapter_covid19/test_economics.py
@@ -4,6 +4,8 @@ Basic example testing the adaptER-covid19 economics class
 
 import sys
 
+import pytest
+
 from adapter_covid19.corporate_bankruptcy import (
     CorporateBankruptcyModel,
     NaiveCorporateBankruptcyModel,
@@ -39,6 +41,9 @@ def pytest_generate_tests(metafunc):
 
 
 class TestClass:
+    # Unfortunately pytest can only check for warnings in stdlib
+    # Otherwise we should parameterise with scipy.optimize.OptimizeWarning
+    @pytest.mark.filterwarnings("ignore:.*:Warning:adapter_covid19.gdp")
     def test_interface(
         self,
         gdp_model_cls,

--- a/tests/adapter_covid19/test_gdp_models.py
+++ b/tests/adapter_covid19/test_gdp_models.py
@@ -6,6 +6,7 @@ import sys
 
 import numpy as np
 import pandas as pd
+import pytest
 
 from adapter_covid19.corporate_bankruptcy import NaiveCorporateBankruptcyModel
 from adapter_covid19.data_structures import PersonalState
@@ -51,6 +52,9 @@ def pytest_generate_tests(metafunc):
 
 
 class TestClass:
+    # Unfortunately pytest can only check for warnings in stdlib
+    # Otherwise we should parameterise with scipy.optimize.OptimizeWarning
+    @pytest.mark.filterwarnings("ignore:.*:Warning:adapter_covid19.gdp")
     def test_interface(self, gdp_model_cls, utilisation):
         reader = Reader(DATA_PATH)
         state = state_from_utilisation(UTILISATION_NO_COVID_NO_LOCKDOWN)


### PR DESCRIPTION
As discussed over email:

* ignores warning about non-full rank LP (see comment)
* replaces divide by zero -> nan -> remove nan with more explicit behaviour (see commit message)

@sbalian 

Thanks