### PR TITLE
Prevent same person being infected twice in seed infections

### DIFF
--- a/src/model.c
+++ b/src/model.c
@@ -507,14 +507,20 @@ void set_up_seed_infection( model *model )
 	parameters *params = model->params;
 	int idx;
 	unsigned long int person;
+	individual *indiv;
 
 	idx = 0;
 	while( idx < params->n_seed_infection )
 	{
 		person = gsl_rng_uniform_int( rng, params->n_total );
-		if( !params->hospital_on || model->population[person].worker_type == NOT_HEALTHCARE_WORKER )
+		indiv  = &(model->population[ person ]);
+
+		if( time_infected( indiv ) != NO_EVENT )
+			continue;
+
+		if( !params->hospital_on || indiv->worker_type == NOT_HEALTHCARE_WORKER )
 		{
-			new_infection( model, &(model->population[ person ]), &(model->population[ person ]) );
+			new_infection( model, indiv, indiv );
 			idx++;
 		}
 	}

--- a/tests/test_infection_dynamics.py
+++ b/tests/test_infection_dynamics.py
@@ -1037,7 +1037,7 @@ class TestClass(object):
         model.one_time_step()
         model.write_transmissions()
         df_trans = pd.read_csv( constant.TEST_TRANSMISSION_FILE, comment="#", sep=",", skipinitialspace=True )  
-        df_trans[ "n_inf_type" ] = int( df_trans[ "time_asymptomatic" ] == 0 ) + int( df_trans[ "time_presymptomatic_mild" ] == 0 ) + int( df_trans[ "time_presymptomatic_severe" ] == 0 )
+        df_trans[ "n_inf_type" ] = (df_trans[ "time_asymptomatic" ] == 0 )*1 + ( df_trans[ "time_presymptomatic_mild" ] == 0 )*1 + ( df_trans[ "time_presymptomatic_severe" ] == 0 )*1
                                    
         np.testing.assert_equal( len( df_trans ), test_params["n_seed_infection"], "The number of seed infections is not equal to the size of the transmission file")
         np.testing.assert_equal( sum( df_trans["n_inf_type"] >1 ), 0, "Individuals with more than one type of infections" )


### PR DESCRIPTION
Fix bug in set_up_seed_infections which allows the same person to be
tested twice. (normally not an issue since we infect 5 out of 1m but in
some tests we have large seed infections for speed)