### PR TITLE
Added param_line_number to hospital output files

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -948,9 +948,13 @@ void write_ward_data( model *model)
 
 	int hospital_idx = 0;
 
+	char param_line_number[10];
+	sprintf(param_line_number, "%d", model->params->param_line_number);
+
 	// Concatenate file name
 	strcpy(output_file_name, model->params->output_file_dir);
 	strcat(output_file_name, "/ward_output");
+	strcat(output_file_name, param_line_number);
 	strcat(output_file_name, ".csv");
 	ward_output_file = fopen(output_file_name, "w");
 
@@ -1397,9 +1401,13 @@ void write_hospital_interactions( model *model )
     int day, hcw_ward_type, hcw_ward_index;
     hospital *hospital = &model->hospitals[0];
 
+    char param_line_number[10];
+    sprintf(param_line_number, "%d", model->params->param_line_number);
+
     // Concatenate file name
     strcpy(output_file_name, model->params->output_file_dir);
     strcat(output_file_name, "/time_step_hospital_interactions");
+    strcat(output_file_name, param_line_number);
     strcat(output_file_name, ".csv");
 
     day = model->interaction_day_idx;
@@ -1484,9 +1492,14 @@ void write_time_step_hospital_data( model *model)
 
     if( model->params->sys_write_hospital )
         {
+            
+            char param_line_number[10];
+            sprintf(param_line_number, "%d", model->params->param_line_number);
+
             // Concatenate file name
             strcpy(output_file_name, model->params->output_file_dir);
             strcat(output_file_name, "/time_step_hospital_output");
+            strcat(output_file_name, param_line_number);
             strcat(output_file_name, ".csv");
 
             // Open outputfile in different mode depending on whether this is the first time step

--- a/tests/constant.py
+++ b/tests/constant.py
@@ -31,9 +31,9 @@ TEST_INTERACTION_FILE = join(DATA_DIR_TEST, "interactions_Run1.csv")
 TEST_TRANSMISSION_FILE = join(DATA_DIR_TEST, "transmission_Run1.csv")
 TEST_TRACE_FILE = join(DATA_DIR_TEST, "trace_tokens_Run1.csv")
 TEST_QUARANTINE_REASONS_FILE = Template(join(DATA_DIR_TEST, "quarantine_reasons_file_Run1_T$T.csv"))
-TEST_HCW_FILE = join(DATA_DIR_TEST, "ward_output.csv")
-TEST_OUTPUT_FILE_HOSPITAL_TIME_STEP = join(DATA_DIR_TEST, "time_step_hospital_output.csv")
-TEST_OUTPUT_FILE_HOSPITAL_INTERACTIONS = join(DATA_DIR_TEST, "time_step_hospital_interactions.csv")
+TEST_HCW_FILE = join(DATA_DIR_TEST, "ward_output1.csv")
+TEST_OUTPUT_FILE_HOSPITAL_TIME_STEP = join(DATA_DIR_TEST, "time_step_hospital_output1.csv")
+TEST_OUTPUT_FILE_HOSPITAL_INTERACTIONS = join(DATA_DIR_TEST, "time_step_hospital_interactions1.csv")
 TEST_HOUSEHOLD_TEMPLATE = "./tests/data/baseline_household_demographics.csv"
 TEST_HOUSEHOLD_FILE = join(DATA_DIR_TEST, "test_household_demographics.csv")
 


### PR DESCRIPTION
src/input.c: edited hospital output file naming to include param_line_number so as to be consistent with other output files

tests/constant.py: edited file paths so that tests find the renamed hospital output files

Fixes #112