### PR TITLE
Bugfix - remove occupation network from params object once set up

### DIFF
--- a/src/model.c
+++ b/src/model.c
@@ -316,6 +316,12 @@ void set_up_occupation_network( model *model )
 
         free( people );
     }
+
+    if( model->use_custom_occupation_networks == FALSE )
+    {
+    	free( params->occupation_network_table );
+    	params->occupation_network_table = NULL;
+    }
 }
 
 /*****************************************************************************************


### PR DESCRIPTION
If model is created multiple times from the same params object then we
get different answers. Problem with the Simulation Python interface, but
not the Model Python interface (so was missed in tests).