### PR TITLE
Enable updating of fatality fraction during run time

### DIFF
--- a/src/COVID19/model.py
+++ b/src/COVID19/model.py
@@ -73,6 +73,15 @@ PYTHON_SAFE_UPDATE_PARAMS = [
     "priority_test_contacts_70_79",
     "priority_test_contacts_80",
     "test_release_on_negative",
+    "fatality_fraction_0_9",
+    "fatality_fraction_10_19",
+    "fatality_fraction_20_29",
+    "fatality_fraction_30_39",
+    "fatality_fraction_40_49",
+    "fatality_fraction_50_59",
+    "fatality_fraction_60_69",
+    "fatality_fraction_70_79",
+    "fatality_fraction_80",
 ]
 
 

--- a/src/params.c
+++ b/src/params.c
@@ -219,6 +219,19 @@ int get_model_param_hospital_on(model *model)
 }
 
 
+/*****************************************************************************************
+*  Name: 		get_model_param_fatality_fraction
+*  Description: Gets the value of a parameter
+******************************************************************************************/
+double get_model_param_fatality_fraction(model * model, int age_group)
+{
+
+    if ( age_group >= N_AGE_GROUPS ) return ERROR;
+
+	return model->params->fatality_fraction[age_group];
+}
+
+
 
 /*****************************************************************************************
 *  Name: 		get_model_param_daily_fraction_work_used
@@ -1291,6 +1304,19 @@ void check_params( parameters *params )
     	}
     }
 }
+
+/*****************************************************************************************
+*  Name:        set_model_param_fatality_fraction
+*  Description: Allow updates of the fatality fraction
+******************************************************************************************/
+int set_model_param_fatality_fraction(model * model, double value, int age_group)
+{
+	if (age_group >= N_AGE_GROUPS) return ERROR;
+	model->params->fatality_fraction[age_group] = value;
+	return TRUE;
+}
+
+
 
 /*****************************************************************************************
 *  Name:        check_hospital_params

--- a/src/params.h
+++ b/src/params.h
@@ -240,6 +240,7 @@ int get_model_param_manual_trace_n_workers( model* model );
 int get_model_param_manual_trace_interviews_per_worker_day( model* model );
 int get_model_param_manual_trace_notifications_per_worker_day( model* model );
 double get_model_param_manual_traceable_fraction( model* model, int );
+double get_model_param_fatality_fraction( model * model, int age_group );
 
 int set_model_param_quarantine_days(model *model, int value);
 int set_model_param_self_quarantine_fraction(model *model, double value);
@@ -283,6 +284,7 @@ int set_model_param_manual_traceable_fraction( model* model, double value, int t
 
 int set_model_param_risk_score( model*, int, int, int, double );
 int set_model_param_risk_score_household( model*, int, int, double );
+int set_model_param_fatality_fraction( model * model, double value, int age_group );
 
 int set_demographic_house_table( parameters*, long, long, long*, long*, long* );
 int set_occupation_network_table( parameters* params,  long n_total, long n_networks );

--- a/tests/test_python_c_interface.py
+++ b/tests/test_python_c_interface.py
@@ -380,3 +380,21 @@ class TestClass(object):
             daily_deaths.append(daily_death)
             assert sum(daily_deaths) == model.one_time_step_results()["total_death"]
         assert sum(daily_deaths) > 0
+
+
+    def test_update_fatality_fraction(self):
+        params = Parameters(
+            constant.TEST_DATA_TEMPLATE,
+            constant.PARAM_LINE_NUMBER,
+            constant.DATA_DIR_TEST,
+            constant.TEST_HOUSEHOLD_FILE,
+            constant.TEST_HOSPITAL_FILE,
+        )
+        model = Model(params)
+        assert model.get_param("fatality_fraction_80") == 1.0
+
+        model.update_running_params("fatality_fraction_80", 0.6)
+        assert model.get_param("fatality_fraction_80") == 0.6
+
+
+


### PR DESCRIPTION
Enable updating of the age based fatality fraction during run time.
This has use when new therapeutics are discovered for covid treatment: eg dexamethasone