### PR TITLE
fix typos in params and documentation.

### DIFF
--- a/documentation/covid19.md
+++ b/documentation/covid19.md
@@ -103,7 +103,7 @@ We define *asymptomatic* individuals as those who never develop symptoms during 
 Both types of individuals may infect others.
 The overall infectiousness of asymptomatic individuals has been estimated to be lower [[6]](#6), reflected in our parameter `asymptomatic_infectious_factor`.
 Individuals who show symptoms but only mildly have also been estimated as less infectious than those with more severe symptoms [[6]](#6), reflected in our parameter `mild_infectious_factor`.
-For each adult age category, we took the fraction of symptomatic infections that are mild as the fraction of confirmed cases with with either no pneumonia (which was rare -- always less than 6.5%) or mild pneumonia, i.e. the fraction without severe pneumonia, reported in [[7]](#7).
+For each adult age category, we took the fraction of symptomatic infections that are mild as the fraction of confirmed cases with either no pneumonia (which was rare -- always less than 6.5%) or mild pneumonia, i.e. the fraction without severe pneumonia, reported in [[7]](#7).
 For the age categories 0-9 and 10-19, we took the fraction of infections that are mild as the fraction clinically defined as 'mild' in the paediatric meta-analysis [[8]](#8), excluding asymptomatic infections from the denominator.
 These fractions of symptomatic infections that are mild by age are listed in Table [Disease dynamics parameters](./parameters/disease_dynamics_parameters.md).
 

--- a/src/params.h
+++ b/src/params.h
@@ -288,7 +288,7 @@ int set_model_param_fatality_fraction( model * model, double value, int age_grou
 
 int set_demographic_house_table( parameters*, long, long, long*, long*, long* );
 int set_occupation_network_table( parameters* params,  long n_total, long n_networks );
-int set_indiv_occupation_network_property( parameters* params, long network, int age_group, double mean_interaction, double lockdown_multiplier, long network_id, const char *network_name );
+int set_indiv_occupation_network_property( parameters* params, long network, int age_type, double mean_interaction, double lockdown_multiplier, long network_id, const char *network_name );
 int set_indiv_occupation_network( parameters* params, long n_total, long *people, long *network );
 void set_up_default_occupation_network_table( parameters *params );
 


### PR DESCRIPTION
The param.c defines age_type, but params.h had age_group. Fix them to be in sync.

Also fix little "with with" typo in covid19.md.