### PR TITLE
fix n_death being the daily number of deaths and total_death being the total as per the docs

### DIFF
--- a/src/COVID19/model.py
+++ b/src/COVID19/model.py
@@ -648,10 +648,6 @@ class Model:
             value = covid19.utils_n_total_age(self.c_model, covid19.DEATH, age.value)
             results[key] = value
 
-        results["daily_death"] = covid19.utils_n_daily(
-                self.c_model, covid19.DEATH, self.c_model.time
-            )
-
         results["n_presymptom"] = covid19.utils_n_current(
             self.c_model, covid19.PRESYMPTOMATIC
         ) + covid19.utils_n_current(self.c_model, covid19.PRESYMPTOMATIC_MILD)
@@ -670,7 +666,7 @@ class Model:
         results["n_hospital"] = covid19.utils_n_current( self.c_model, covid19.HOSPITALISED )
         results["n_hospitalised_recovering"] = covid19.utils_n_current( self.c_model, covid19.HOSPITALISED_RECOVERING )
         results["n_critical"] = covid19.utils_n_current(self.c_model, covid19.CRITICAL)
-        results["n_death"] = covid19.utils_n_current(self.c_model, covid19.DEATH)
+        results["n_death"] = covid19.utils_n_daily(self.c_model, covid19.DEATH, self.c_model.time)
         results["n_recovered"] = covid19.utils_n_current(
             self.c_model, covid19.RECOVERED
         )

--- a/tests/test_python_c_interface.py
+++ b/tests/test_python_c_interface.py
@@ -376,7 +376,7 @@ class TestClass(object):
         daily_deaths = []
         for step in range(50):
             model.one_time_step()
-            daily_death = model.one_time_step_results()["daily_death"]
+            daily_death = model.one_time_step_results()["n_death"]
             daily_deaths.append(daily_death)
             assert sum(daily_deaths) == model.one_time_step_results()["total_death"]
         assert sum(daily_deaths) > 0

--- a/tests/test_python_c_interface.py
+++ b/tests/test_python_c_interface.py
@@ -381,7 +381,6 @@ class TestClass(object):
             assert sum(daily_deaths) == model.one_time_step_results()["total_death"]
         assert sum(daily_deaths) > 0
 
-
     def test_update_fatality_fraction(self):
         params = Parameters(
             constant.TEST_DATA_TEMPLATE,


### PR DESCRIPTION
```
| `n_death` | Daily number of deaths | timeseries |
| `total_death` | Cumulative deaths (where COVID19 is the primary cause of death) | timeseries |
```

are in docs but `n_death` used to output the same as `total_death`