### PR TITLE
Allow more differences of strains/variants to the wild-type

### DIFF
--- a/NAMESPACE
+++ b/NAMESPACE
@@ -58,6 +58,7 @@ export("VACCINE_TYPES")
 export("VACCINE_STATUS")
 
 # constants
+export( "UNKNOWN" )
 export("plot.value.total_infected")
 export("plot.value.new_infected")
 export("plot.values")

--- a/R/MetaModel.R
+++ b/R/MetaModel.R
@@ -875,7 +875,12 @@ MetaModel <- R6Class( classname = 'MetaModel', cloneable = FALSE,
       return()
     },
 
-    add_new_strain = function( transmission_multiplier = 1, hospitalised_fraction = NA, hospitalised_fraction_multiplier = 1 )
+    add_new_strain = function( 
+    	transmission_multiplier = 1, 
+    	hospitalised_fraction = NA, 
+    	hospitalised_fraction_multiplier = 1,
+    	mean_infectious_period = NA
+    )
     {
         if( self$n_strains == self$base_params[[ 1 ]][[ "max_n_strains" ]] )
           stop( "max_n_strains strains have been added already" )
@@ -886,7 +891,8 @@ MetaModel <- R6Class( classname = 'MetaModel', cloneable = FALSE,
             strain <- abms[[ nidx ]]$add_new_strain(
               transmission_multiplier = data$transmission_multiplier ,
               hospitalised_fraction   = data$hospitalised_fraction,
-              hospitalised_fraction_multiplier = data$hospitalised_fraction_multiplier
+              hospitalised_fraction_multiplier = data$hospitalised_fraction_multiplier,
+              mean_infectious_period = data$mean_infectious_period
             )
             strain_idx <- strain$idx()
             strains[[ nidx ]][[ strain_idx + 1 ]] <<- strain
@@ -898,13 +904,14 @@ MetaModel <- R6Class( classname = 'MetaModel', cloneable = FALSE,
         data <- list(
           transmission_multiplier = transmission_multiplier ,
           hospitalised_fraction   = hospitalised_fraction,
-          hospitalised_fraction_multiplier = hospitalised_fraction_multiplier
+          hospitalised_fraction_multiplier = hospitalised_fraction_multiplier,
+          mean_infectious_period = mean_infectious_period
         )
-        data <- replicate( self$n_nodes, data, simplify = FALSE )
+        node_data <- replicate( self$n_nodes, data, simplify = FALSE )
 
-        t <- clusterApply( private$.cluster(), data, add_new_strain_func )
+        t <- clusterApply( private$.cluster(), node_data, add_new_strain_func )
         private$.n_strains <- t[[ 1 ]] + 1
-        private$.strain_params[[ private$.n_strains  ]] <- list( transmission_multiplier = transmission_multiplier )
+        private$.strain_params[[ private$.n_strains  ]] <- data
 
         return( t[[ 1 ]]);
     },

--- a/R/Model.R
+++ b/R/Model.R
@@ -718,11 +718,11 @@ Model <- R6Class( classname = 'Model', cloneable = FALSE,
     #' @param transmission_multiplier The relative transmission rate of the strain
     #' @param hospitalised_fraction the fraction of symptomatic (not mild) who progress to hospital [default: None is no change)]
     #' @return \code{Strain} A Strain object representing this strain
-    add_new_strain = function( 
-    	transmission_multiplier = 1, 
-    	hospitalised_fraction = NA, 
+    add_new_strain = function(
+    	transmission_multiplier = 1,
+    	hospitalised_fraction = NA,
     	hospitalised_fraction_multiplier = 1,
-    	mean_infectious_rate = NA
+    	mean_infectious_period = NA
     )
     {
 
@@ -740,13 +740,13 @@ Model <- R6Class( classname = 'Model', cloneable = FALSE,
             sprintf( "hospitalised_fraction%s", names( AgeGroupEnum[idx])) ) *
             hospitalised_fraction_multiplier
       }
-      
-      if( is.na( mean_infectious_rate ) )
-      	mean_infectious_rate = UNKNOWN;
+
+      if( is.na( mean_infectious_period ) )
+      	mean_infectious_period = UNKNOWN;
 
       c_model_ptr <- private$c_model_ptr()
       strain_idx<-.Call('R_add_new_strain',c_model_ptr,transmission_multiplier,
-                        hospitalised_fraction, PACKAGE='OpenABMCovid19');
+                        hospitalised_fraction, mean_infectious_period, PACKAGE='OpenABMCovid19');
 
       private$.strains[[ strain_idx + 1 ]] <- Strain$new( self, strain_idx )
       return( private$.strains[[ strain_idx + 1 ]] )

--- a/R/Model.R
+++ b/R/Model.R
@@ -718,7 +718,12 @@ Model <- R6Class( classname = 'Model', cloneable = FALSE,
     #' @param transmission_multiplier The relative transmission rate of the strain
     #' @param hospitalised_fraction the fraction of symptomatic (not mild) who progress to hospital [default: None is no change)]
     #' @return \code{Strain} A Strain object representing this strain
-    add_new_strain = function( transmission_multiplier = 1, hospitalised_fraction = NA, hospitalised_fraction_multiplier = 1 )
+    add_new_strain = function( 
+    	transmission_multiplier = 1, 
+    	hospitalised_fraction = NA, 
+    	hospitalised_fraction_multiplier = 1,
+    	mean_infectious_rate = NA
+    )
     {
 
       max_n_strains = self$get_param( "max_n_strains" )
@@ -735,6 +740,9 @@ Model <- R6Class( classname = 'Model', cloneable = FALSE,
             sprintf( "hospitalised_fraction%s", names( AgeGroupEnum[idx])) ) *
             hospitalised_fraction_multiplier
       }
+      
+      if( is.na( mean_infectious_rate ) )
+      	mean_infectious_rate = UNKNOWN;
 
       c_model_ptr <- private$c_model_ptr()
       strain_idx<-.Call('R_add_new_strain',c_model_ptr,transmission_multiplier,

--- a/R/util.R
+++ b/R/util.R
@@ -232,6 +232,7 @@ VACCINE_STATUS <- c(
 )
 
 MAX_TIME <- 1000
+UNKNOWN <- -1
 
 get_base_param_from_enum <- function(param) {
   allEnums <- c(

--- a/src/COVID19/model.py
+++ b/src/COVID19/model.py
@@ -855,7 +855,7 @@ class Model:
 
     def add_new_strain(
             self, 
-            transmission_multiplier, 
+            transmission_multiplier = 1, 
             hospitalised_fraction = None,  
             mean_infectious_period = None,
         ):     
@@ -866,7 +866,7 @@ class Model:
         
         transmission_multiplier - the relative transmissibility of the new strain
         hospitalised_fraction - the fraction of symptomatic (not mild) who progress to hospital [default: None is no change)
-        mean_infectious_rate - the mean infectious period (default: is no change)
+        mean_infectious_period - the mean infectious period (default: is no change)
         """  
 
         n_strains = self.c_model.n_initialised_strains;
@@ -881,8 +881,8 @@ class Model:
         else :
             for idx in range( len(AgeGroupEnum ) ) :
                 hospitalised_fraction_c[ idx ] = hospitalised_fraction[ idx ]
-        if mean_infectious_rate == None :
-            mean_infectious_rate = covid19.UNKNOWN
+        if mean_infectious_period == None :
+            mean_infectious_period = covid19.UNKNOWN
            
         idx = covid19.add_new_strain( self.c_model, transmission_multiplier, hospitalised_fraction_c, mean_infectious_period );
 

--- a/src/COVID19/model.py
+++ b/src/COVID19/model.py
@@ -853,7 +853,12 @@ class Model:
         return covid19.seed_infect_by_idx( self.c_model, ID, strain_idx, network_id );
     
 
-    def add_new_strain(self, transmission_multiplier, hospitalised_fraction = None ):     
+    def add_new_strain(
+            self, 
+            transmission_multiplier, 
+            hospitalised_fraction = None,  
+            mean_infectious_period = None,
+        ):     
         
         """
         Add a new strain, note the total number of strains that can be added is set by the initial 
@@ -861,7 +866,7 @@ class Model:
         
         transmission_multiplier - the relative transmissibility of the new strain
         hospitalised_fraction - the fraction of symptomatic (not mild) who progress to hospital [default: None is no change)
-        
+        mean_infectious_rate - the mean infectious period (default: is no change)
         """  
 
         n_strains = self.c_model.n_initialised_strains;
@@ -876,8 +881,10 @@ class Model:
         else :
             for idx in range( len(AgeGroupEnum ) ) :
                 hospitalised_fraction_c[ idx ] = hospitalised_fraction[ idx ]
+        if mean_infectious_rate == None :
+            mean_infectious_rate = covid19.UNKNOWN
            
-        idx = covid19.add_new_strain( self.c_model, transmission_multiplier, hospitalised_fraction_c );
+        idx = covid19.add_new_strain( self.c_model, transmission_multiplier, hospitalised_fraction_c, mean_infectious_period );
 
         return Strain( self, idx )
 

--- a/src/COVID19/network.py
+++ b/src/COVID19/network.py
@@ -50,6 +50,12 @@ class Network:
         
     def transmission_multiplier(self):
         return self.c_network.transmission_multiplier
+    
+    def transmission_multiplier_type(self):
+        return self.c_network.transmission_multiplier_type
+
+    def transmission_multiplier_combined(self):
+        return self.c_network.transmission_multiplier_combined
 
     def show(self):
         print( "network_id        = " + str( self.network_id() ) )
@@ -61,6 +67,8 @@ class Network:
         print( "type              = " + str( self.type() ) )
         print( "daily_fraction    = " + str( self.daily_fraction() ) )
         print( "transmission_mult = " + str( self.transmission_multiplier() ) )
+        print( "transmission_mult_type = " + str( self.transmission_multiplier_type() ) )
+        print( "transmission_mult_comb = " + str( self.transmission_multiplier_combined() ) )
     
     def get_network(self):
         """Return pandas.DataFrame of the network"""

--- a/src/R_C_interface.c
+++ b/src/R_C_interface.c
@@ -370,19 +370,20 @@ SEXP R_get_transmissions ( SEXP R_c_model )
 }
 
 SEXP R_add_new_strain ( SEXP R_c_model, SEXP R_transisition_multiplier,
-                        SEXP R_hospitalised_fraction )
+                        SEXP R_hospitalised_fraction, SEXP R_mean_infectious_period )
 {
   // get the point to the model from the R pointer object
   model *c_model = (model *) R_ExternalPtrAddr(R_c_model);
 
   // allocate memory to for the function call
   float transition_multiplier = asReal( R_transisition_multiplier );
+  float mean_infectious_period = asReal( R_mean_infectious_period );
   double *hospitalised_fraction = calloc( N_AGE_GROUPS, sizeof(double) );
 
   for( int i = 0; i < N_AGE_GROUPS; i++ )
     hospitalised_fraction[ i ] = REAL(R_hospitalised_fraction )[ i ];
 
-  int n_strain = add_new_strain(c_model,transition_multiplier, hospitalised_fraction);
+  int n_strain = add_new_strain(c_model,transition_multiplier, hospitalised_fraction, mean_infectious_period);
 
   free( hospitalised_fraction );
 

--- a/src/disease.c
+++ b/src/disease.c
@@ -134,30 +134,6 @@ void set_up_infectious_curves( model *model )
 			params->adjusted_susceptibility[group] = params->relative_susceptibility[group] * model->mean_interactions_by_age[AGE_TYPE_ADULT] / model->mean_interactions_by_age[AGE_TYPE_MAP[group]];
 	}
 	params->infectious_rate_adjusted = infectious_rate;
-
-	gamma_rate_curve( model->event_lists[PRESYMPTOMATIC].infectious_curve, MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
-					  params->sd_infectious_period, infectious_rate );
-
-	gamma_rate_curve( model->event_lists[PRESYMPTOMATIC_MILD].infectious_curve, MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
-					  params->sd_infectious_period, infectious_rate * params->mild_infectious_factor  );
-
-	gamma_rate_curve( model->event_lists[ASYMPTOMATIC].infectious_curve, MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
-					  params->sd_infectious_period, infectious_rate * params->asymptomatic_infectious_factor);
-
-	gamma_rate_curve( model->event_lists[SYMPTOMATIC].infectious_curve, MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
-					  params->sd_infectious_period, infectious_rate );
-
-	gamma_rate_curve( model->event_lists[SYMPTOMATIC_MILD].infectious_curve, MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
-					  params->sd_infectious_period, infectious_rate * params->mild_infectious_factor );
-
-	gamma_rate_curve( model->event_lists[HOSPITALISED].infectious_curve, MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
-					  params->sd_infectious_period, infectious_rate );
-
-	gamma_rate_curve( model->event_lists[HOSPITALISED_RECOVERING].infectious_curve, MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
-						  params->sd_infectious_period, infectious_rate );
-
-	gamma_rate_curve( model->event_lists[CRITICAL].infectious_curve, MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
-					  params->sd_infectious_period, infectious_rate  );
 }
 /*****************************************************************************************
 *  Name:		transmit_virus_by_type
@@ -178,6 +154,7 @@ void transmit_virus_by_type(
 	interaction *interaction;
 	individual *infector;
 	int rebuild_networks = model->params->rebuild_networks;
+	double *infectious_curve;
 
 	for( day = model->time-1; day >= max( 0, model->time - MAX_INFECTIOUS_PERIOD ); day-- )
 	{
@@ -200,6 +177,7 @@ void transmit_virus_by_type(
 				interaction   = infector->interactions[ model->interaction_day_idx ];
 				infector_mult = infector->infectiousness_multiplier * infector->infection_events->strain->transmission_multiplier;
 				strain_idx 	  = infector->infection_events->strain->idx;
+				infectious_curve = infector->infection_events->strain->infectious_curve[type];
 
 				for( jdx = 0; jdx < n_interaction; jdx++ )
 				{
@@ -221,7 +199,7 @@ void transmit_virus_by_type(
 						}
 
 						network_mult  = model->all_networks[ interaction->network_id ]->transmission_multiplier_combined;
-						hazard_rate   = list->infectious_curve[ t_infect - 1 ] * infector_mult * network_mult;
+						hazard_rate   = infectious_curve[ t_infect - 1 ] * infector_mult * network_mult;
 						interaction->individual->hazard[ strain_idx ] -= hazard_rate;
 
 						if( interaction->individual->hazard[ strain_idx ] < 0 )

--- a/src/interventions.c
+++ b/src/interventions.c
@@ -322,17 +322,12 @@ void remove_traced_on_this_trace( model *model, individual *indiv )
 void update_intervention_policy( model *model, int time )
 {
 	parameters *params = model->params;
-	int type;
 
 	if( time == 0 )
 	{
 		params->app_turned_on       = FALSE;
 		params->lockdown_on	        = FALSE;
 		params->lockdown_elderly_on	= FALSE;
-
-		for( type = 0; type < N_INTERACTION_TYPES; type++ )
-			params->relative_transmission_used[type] = params->relative_transmission[type];
-
 		params->interventions_on = ( params->intervention_start_time == 0 );
 	}
 

--- a/src/model.c
+++ b/src/model.c
@@ -53,6 +53,9 @@ model* new_model( parameters *params )
         model_ptr->n_occupation_networks = params->occupation_network_table->n_networks;
     }
 
+	for( type = 0; type < N_INTERACTION_TYPES; type++ )
+		params->relative_transmission_used[type] = params->relative_transmission[type];
+
     gsl_rng_env_setup();
     rng = gsl_rng_alloc ( gsl_rng_default);
     gsl_rng_set( rng, params->rng_seed );
@@ -247,7 +250,7 @@ void destroy_event_list( model *model, int type )
 ******************************************************************************************/
 network* add_new_network( model *model, long n_total, int type )
 {
-	network *net = create_network( n_total, type );
+	network *net = create_network( n_total, type, model->params );
 
 	net->network_id = model->n_networks;
 

--- a/src/model.c
+++ b/src/model.c
@@ -180,7 +180,7 @@ void destroy_model( model *model )
     }
     destroy_risk_scores( model );
 
-    for( idx = 0; idx < model->params->max_n_strains; idx++ )
+    for( idx = 0; idx < model->n_initialised_strains; idx++ )
     	destroy_strain( &(model->strains[ idx ]) );
     free( model->strains );
     for( idx = 0; idx < model->params->max_n_strains; idx++ )
@@ -756,7 +756,7 @@ void set_up_seed_infection( model *model )
 		hospitalised_fraction[ idx ] = params->hospitalised_fraction[ idx ];
 
 	idx = 0;
-	strain_idx = add_new_strain( model, 1, hospitalised_fraction );
+	strain_idx = add_new_strain( model, 1, hospitalised_fraction, UNKNOWN );
 
 	while( idx < params->n_seed_infection )
 	{

--- a/src/model.c
+++ b/src/model.c
@@ -180,6 +180,8 @@ void destroy_model( model *model )
     }
     destroy_risk_scores( model );
 
+    for( idx = 0; idx < model->params->max_n_strains; idx++ )
+    	destroy_strain( &(model->strains[ idx ]) );
     free( model->strains );
     for( idx = 0; idx < model->params->max_n_strains; idx++ )
 		free( model->cross_immunity[idx] );
@@ -217,7 +219,6 @@ void set_up_event_list( model *model, parameters *params, int type )
 		list->n_daily[day] = 0;
 		list->n_daily_current[day] = 0;
 	}
-	list->infectious_curve = calloc( MAX_INFECTIOUS_PERIOD, sizeof(double) );
 }
 
 /*****************************************************************************************
@@ -233,7 +234,6 @@ void destroy_event_list( model *model, int type )
 		free( model->event_lists[type].n_daily_by_age[day]);
 
 	free( model->event_lists[type].n_daily_current );
-	free( model->event_lists[type].infectious_curve );
 	free( model->event_lists[type].n_total_by_age );
 	free( model->event_lists[type].n_daily_by_age );
 	free( model->event_lists[type].events );

--- a/src/model.c
+++ b/src/model.c
@@ -196,13 +196,12 @@ void destroy_model( model *model )
 void set_up_event_list( model *model, parameters *params, int type )
 {
 
-	int day, age, idx;
+	int day, age;
 	event_list *list = &(model->event_lists[ type ]);
 	list->type       = type;
 
 	list->n_daily          = calloc( MAX_TIME, sizeof(long) );
 	list->n_daily_current  = calloc( MAX_TIME, sizeof(long) );
-	list->infectious_curve = calloc( N_INTERACTION_TYPES, sizeof(double*) );
 	list->n_total_by_age   = calloc( N_AGE_GROUPS, sizeof(long) );
 	list->n_daily_by_age   = calloc( MAX_TIME, sizeof(long*) );
 	list->events		   = calloc( MAX_TIME, sizeof(event*));
@@ -218,8 +217,7 @@ void set_up_event_list( model *model, parameters *params, int type )
 		list->n_daily[day] = 0;
 		list->n_daily_current[day] = 0;
 	}
-	for( idx = 0; idx < N_INTERACTION_TYPES; idx++ )
-		list->infectious_curve[idx] = calloc( MAX_INFECTIOUS_PERIOD, sizeof(double) );
+	list->infectious_curve = calloc( MAX_INFECTIOUS_PERIOD, sizeof(double) );
 }
 
 /*****************************************************************************************
@@ -228,13 +226,11 @@ void set_up_event_list( model *model, parameters *params, int type )
 ******************************************************************************************/
 void destroy_event_list( model *model, int type )
 {
-	int day, idx;
+	int day;
 	free( model->event_lists[type].n_daily );
 
 	for( day = 0; day < MAX_TIME; day++ )
 		free( model->event_lists[type].n_daily_by_age[day]);
-	for( idx = 0; idx < N_INTERACTION_TYPES; idx++ )
-		free( model->event_lists[type].infectious_curve[idx] );
 
 	free( model->event_lists[type].n_daily_current );
 	free( model->event_lists[type].infectious_curve );

--- a/src/model.h
+++ b/src/model.h
@@ -33,7 +33,7 @@ struct event_list{
 	long n_total;
 	long *n_total_by_age;
 	long n_current;
-	double **infectious_curve;
+	double *infectious_curve;
 };
 
 struct directory{

--- a/src/model.h
+++ b/src/model.h
@@ -33,7 +33,6 @@ struct event_list{
 	long n_total;
 	long *n_total_by_age;
 	long n_current;
-	double *infectious_curve;
 };
 
 struct directory{

--- a/src/network.c
+++ b/src/network.c
@@ -17,7 +17,7 @@
 *  				 1. Creates memory for it
 *  Returns:		pointer to model
 ******************************************************************************************/
-network* create_network( long n_total, int type )
+network* create_network( long n_total, int type, parameters *params )
 {	
 	network *network_ptr = NULL;
 	network_ptr = calloc( 1, sizeof( network ) );
@@ -28,6 +28,7 @@ network* create_network( long n_total, int type )
 	network_ptr->n_vertices = n_total;
 	network_ptr->type       = type;
 	network_ptr->transmission_multiplier = 1;
+	update_transmission_multiplier_type( network_ptr, params->relative_transmission_used[type] );
 	
 	return network_ptr;
 }
@@ -267,6 +268,28 @@ int update_daily_fraction( network *network, double fraction )
 	}
 
 	network->daily_fraction = fraction;
+	return TRUE;
+}
+
+/*****************************************************************************************
+*  Name:		update_transmission_multiplier
+*  Description: Updates the bespoke transmission_multiplier on the network
+******************************************************************************************/
+int update_transmission_multiplier( network *network, float multiplier )
+{
+	network->transmission_multiplier = multiplier;
+	network->transmission_multiplier_combined = network->transmission_multiplier * network->transmission_multiplier_type;
+	return TRUE;
+}
+
+/*****************************************************************************************
+*  Name:		update_transmission_multiplier_type
+*  Description: Updates the network type transmission_multiplier the network
+******************************************************************************************/
+int update_transmission_multiplier_type( network *network, float multiplier )
+{
+	network->transmission_multiplier_type = multiplier;
+	network->transmission_multiplier_combined = network->transmission_multiplier * network->transmission_multiplier_type;
 	return TRUE;
 }
 

--- a/src/network.h
+++ b/src/network.h
@@ -40,6 +40,8 @@ struct network{
 	int network_id;				// unique network ID
 	char name[INPUT_CHAR_LEN]; 	// unique name of the network
 	float transmission_multiplier; // bespoke transmission multiplier for network
+	float transmission_multiplier_type;     // combined network type and bespoke network multiplier
+	float transmission_multiplier_combined; // combined network type and bespoke network multiplier
 
 	int construction;			// method used to construct the network
 	long opt_n_indiv;			// (OPTIONAL) number of distinct individuals on an network
@@ -55,7 +57,7 @@ struct network{
 /******************************  Functions  *****************************/
 /************************************************************************/
 
-network* create_network(long n_total, int type);
+network* create_network(long n_total, int type, parameters* );
 void build_watts_strogatz_network( network *, long, double, double, int );
 int check_member_or_self(long , long, long *, long );
 void remove_contact(long *, long , long *);
@@ -63,5 +65,7 @@ void add_contact(long *, long , long *);
 void relabel_network( network*, long*  );
 void destroy_network( network* );
 int update_daily_fraction( network*, double );
+int update_transmission_multiplier( network*, float );
+int update_transmission_multiplier_type( network*, float );
 
 #endif /* NETWORK_H_ */

--- a/src/network_utils.i
+++ b/src/network_utils.i
@@ -39,7 +39,16 @@ float network_transmission_multiplier( network *pnetwork ) {
 	return pnetwork->transmission_multiplier;
 } 
 
+float network_transmission_multiplier_type( network *pnetwork ) {
+	return pnetwork->transmission_multiplier_type;
+} 
+
+float network_transmission_multiplier_combined( network *pnetwork ) {
+	return pnetwork->transmission_multiplier_combined;
+} 
+
 void set_network_transmission_multiplier( network *pnetwork, float val ) {
+	update_transmission_multiplier( pnetwork, val );
 	pnetwork->transmission_multiplier = val;
 }
 

--- a/src/params.c
+++ b/src/params.c
@@ -1089,7 +1089,6 @@ int set_model_param_relative_transmission( model *model, double value, int type 
 			update_transmission_multiplier_type( network, model->params->relative_transmission_used[ type ] );
 	}
 
-	set_up_infectious_curves( model );
 	return TRUE;
 }
 
@@ -1274,7 +1273,6 @@ int set_model_param_lockdown_on( model *model, int value )
 		update_household_intervention_state(model, value);
 	}
 	params->lockdown_on = value;
-	set_up_infectious_curves( model );
 
 	for( pdx = 0; pdx < params->n_total; pdx++ )
 		update_random_interactions( &(model->population[pdx]), params );
@@ -1334,7 +1332,6 @@ int set_model_param_lockdown_elderly_on( model *model, int value )
 		return FALSE;
 	}
 	params->lockdown_elderly_on = value;
-	set_up_infectious_curves( model );
 
 	for( pdx = 0; pdx < params->n_total; pdx++ )
 	{

--- a/src/params.h
+++ b/src/params.h
@@ -42,6 +42,7 @@ typedef struct{
 	double mean_infectious_period;  // mean period in days that people are infectious
 	double sd_infectious_period;	// sd of period in days that people are infectious
 	double infectious_rate;         // mean total number of people infected for a mean person
+	double infectious_rate_adjusted;// infectious rate adjusted for the default mean number of interactions
 	double sd_infectiousness_multiplier;         // sd of the lognormal used to vary the infectiousness of an individual
 
 	double relative_susceptibility[N_AGE_GROUPS]; // relative susceptibility of an age group

--- a/src/strain.c
+++ b/src/strain.c
@@ -12,12 +12,17 @@
 /*****************************************************************************************
 *  Name:		add_new_strain
 *  Description: Initialises new strain, can only be called once for each strain
+*  Arguments:	model  - pointer to model structurture
+*  				transmission_multiplier - strain specific transmission multiplier
+*  				hospitalised_fraction   - strain specific hospitalised fraction
+*  				mean_infectious_period  - strain specific mean_infectious_period (UNKOWN then use default)
 *  Returns:		void
 ******************************************************************************************/
 short add_new_strain(
 	model *model,
 	float transmission_multiplier,
-	double *hospitalised_fraction
+	double *hospitalised_fraction,
+	double mean_infectious_period
 )
 {
 	double infectious_rate;
@@ -26,6 +31,10 @@ short add_new_strain(
 
 	if( model->n_initialised_strains == model->params->max_n_strains )
 		return ERROR;
+
+	// if parameters are unspecified then use default values
+	if( mean_infectious_period == UNKNOWN )
+		mean_infectious_period = params->mean_infectious_period;
 
 	strain_ptr = &(model->strains[ model->n_initialised_strains ]);
 	strain_ptr->idx 					= model->n_initialised_strains;
@@ -39,35 +48,35 @@ short add_new_strain(
 	strain_ptr->infectious_curve = calloc( N_EVENT_TYPES, sizeof(double) );
 
 	strain_ptr->infectious_curve[PRESYMPTOMATIC] = calloc( MAX_INFECTIOUS_PERIOD, sizeof(double) );
-	gamma_rate_curve( strain_ptr->infectious_curve[PRESYMPTOMATIC], MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
+	gamma_rate_curve( strain_ptr->infectious_curve[PRESYMPTOMATIC], MAX_INFECTIOUS_PERIOD, mean_infectious_period,
 					  params->sd_infectious_period, infectious_rate );
 
 	strain_ptr->infectious_curve[PRESYMPTOMATIC_MILD] = calloc( MAX_INFECTIOUS_PERIOD, sizeof(double) );
-	gamma_rate_curve( strain_ptr->infectious_curve[PRESYMPTOMATIC_MILD], MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
+	gamma_rate_curve( strain_ptr->infectious_curve[PRESYMPTOMATIC_MILD], MAX_INFECTIOUS_PERIOD, mean_infectious_period,
 					  params->sd_infectious_period, infectious_rate * params->mild_infectious_factor  );
 
 	strain_ptr->infectious_curve[ASYMPTOMATIC] = calloc( MAX_INFECTIOUS_PERIOD, sizeof(double) );
-	gamma_rate_curve( strain_ptr->infectious_curve[ASYMPTOMATIC] , MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
+	gamma_rate_curve( strain_ptr->infectious_curve[ASYMPTOMATIC] , MAX_INFECTIOUS_PERIOD, mean_infectious_period,
 					  params->sd_infectious_period, infectious_rate * params->asymptomatic_infectious_factor);
 
 	strain_ptr->infectious_curve[SYMPTOMATIC] = calloc( MAX_INFECTIOUS_PERIOD, sizeof(double) );
-	gamma_rate_curve( strain_ptr->infectious_curve[SYMPTOMATIC], MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
+	gamma_rate_curve( strain_ptr->infectious_curve[SYMPTOMATIC], MAX_INFECTIOUS_PERIOD, mean_infectious_period,
 					  params->sd_infectious_period, infectious_rate );
 
 	strain_ptr->infectious_curve[SYMPTOMATIC_MILD] = calloc( MAX_INFECTIOUS_PERIOD, sizeof(double) );
-	gamma_rate_curve( strain_ptr->infectious_curve[SYMPTOMATIC_MILD], MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
+	gamma_rate_curve( strain_ptr->infectious_curve[SYMPTOMATIC_MILD], MAX_INFECTIOUS_PERIOD, mean_infectious_period,
 					  params->sd_infectious_period, infectious_rate * params->mild_infectious_factor );
 
 	strain_ptr->infectious_curve[HOSPITALISED] = calloc( MAX_INFECTIOUS_PERIOD, sizeof(double) );
-	gamma_rate_curve( strain_ptr->infectious_curve[HOSPITALISED], MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
+	gamma_rate_curve( strain_ptr->infectious_curve[HOSPITALISED], MAX_INFECTIOUS_PERIOD, mean_infectious_period,
 					  params->sd_infectious_period, infectious_rate );
 
 	strain_ptr->infectious_curve[HOSPITALISED_RECOVERING] = calloc( MAX_INFECTIOUS_PERIOD, sizeof(double) );
-	gamma_rate_curve( strain_ptr->infectious_curve[HOSPITALISED_RECOVERING], MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
+	gamma_rate_curve( strain_ptr->infectious_curve[HOSPITALISED_RECOVERING], MAX_INFECTIOUS_PERIOD, mean_infectious_period,
 						  params->sd_infectious_period, infectious_rate );
 
 	strain_ptr->infectious_curve[CRITICAL] = calloc( MAX_INFECTIOUS_PERIOD, sizeof(double) );
-	gamma_rate_curve( strain_ptr->infectious_curve[CRITICAL], MAX_INFECTIOUS_PERIOD, params->mean_infectious_period,
+	gamma_rate_curve( strain_ptr->infectious_curve[CRITICAL], MAX_INFECTIOUS_PERIOD, mean_infectious_period,
 					  params->sd_infectious_period, infectious_rate  );
 
 	model->n_initialised_strains++;

--- a/src/strain.h
+++ b/src/strain.h
@@ -26,6 +26,7 @@ struct strain{
 	float transmission_multiplier;
 	double hospitalised_fraction[N_AGE_GROUPS];
 	long total_infected;
+	double **infectious_curve;
 };
 
 /************************************************************************/
@@ -33,6 +34,7 @@ struct strain{
 /************************************************************************/
 
 short add_new_strain( model*, float, double* );
+void destroy_strain( strain* );
 strain* get_strain_by_id( model*, short );
 
 #endif /* STRAIN_H_ */

--- a/src/strain.h
+++ b/src/strain.h
@@ -33,7 +33,7 @@ struct strain{
 /******************************  Functions  *****************************/
 /************************************************************************/
 
-short add_new_strain( model*, float, double* );
+short add_new_strain( model*, float, double*, double );
 void destroy_strain( strain* );
 strain* get_strain_by_id( model*, short );
 

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -425,6 +425,14 @@ class TestClass(object):
                 working_mult = 1.3,
                 primary_mult = 0.7,
                 house_mult  = 1.8   
+            ),
+            dict(
+                test_params = dict( n_total = 10000 ),
+                random_mult = 0.7,
+                occupation_mult =0.3,
+                working_mult = 3,
+                primary_mult = 0.3,
+                house_mult  = 0.8   
             )
         ]
     }

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -416,6 +416,16 @@ class TestClass(object):
                     end_time = 20
                 )
             )
+        ],
+        "test_network_transmission_multipler_update": [
+            dict(
+                test_params = dict( n_total = 10000 ),
+                random_mult = 1.5,
+                occupation_mult = 1.2,
+                working_mult = 1.3,
+                primary_mult = 0.7,
+                house_mult  = 1.8   
+            )
         ]
     }
     """
@@ -1149,4 +1159,86 @@ class TestClass(object):
         transmissions_inter = pd.merge( transmissions, inter_initial, on = [ "ID_1", "ID_2" ], how = "inner")
         np.testing.assert_( len( transmissions ) > 100, "insufficient interactions to test" )
         np.testing.assert_( len( transmissions ) == len( transmissions_inter ), "transmissions not on an initial interaction" )
-               
+    
+    def test_network_transmission_multipler_update(self, test_params, random_mult, occupation_mult, working_mult, primary_mult, house_mult ): 
+    
+        """
+        Test network transmission multiplier
+        
+        Check to see the network transmission multipliers can be updated correctly
+        """
+        
+        params = utils.get_params_swig()
+        for param, value in test_params.items():
+            params.set_param( param, value )  
+        model = utils.get_model_swig( params )
+        model.run( n_steps = 3, verbose = False )
+        
+        model.update_running_params( "relative_transmission_occupation", occupation_mult )
+        model.update_running_params( "relative_transmission_random", random_mult )
+        model.update_running_params( "relative_transmission_household", house_mult )
+        
+        # get the network objects
+        network_info = model.get_network_info().sort_values(["id"])
+        network_names = network_info[ "name"]
+        house_idx   = [i for i, s in enumerate(network_names) if 'Household' in s][0]
+        working_idx = [i for i, s in enumerate(network_names) if 'working' in s][0]
+        primary_idx = [i for i, s in enumerate(network_names) if 'primary' in s][0]
+        random_idx  = [i for i, s in enumerate(network_names) if 'Random' in s][0]
+        
+        house_network   = model.get_network_by_id( house_idx )
+        working_network = model.get_network_by_id( working_idx )
+        primary_network = model.get_network_by_id( primary_idx )
+        random_network  = model.get_network_by_id( random_idx )
+        
+        # update the multipliers
+        house_network.set_network_transmission_multiplier( house_mult )
+        working_network.set_network_transmission_multiplier( working_mult )
+        primary_network.set_network_transmission_multiplier( primary_mult )
+        random_network.set_network_transmission_multiplier( random_mult )
+        
+        np.testing.assert_approx_equal(house_network.transmission_multiplier(), house_mult,
+                                       err_msg = "household network transmission multiplier incorrectly set")  
+        np.testing.assert_approx_equal(working_network.transmission_multiplier(), working_mult,
+                                       err_msg = "working network transmission multiplier incorrectly set")  
+        np.testing.assert_approx_equal(primary_network.transmission_multiplier(), primary_mult,
+                                       err_msg = "primary network transmission multiplier incorrectly set")        
+        np.testing.assert_approx_equal(random_network.transmission_multiplier(), random_mult,
+                                       err_msg = "random network transmission multiplier incorrectly set")  
+         
+        np.testing.assert_approx_equal(house_network.transmission_multiplier_type(), house_mult,
+                                       err_msg = "household network transmission multiplier incorrectly set")    
+        np.testing.assert_approx_equal(working_network.transmission_multiplier_type(), occupation_mult,
+                                       err_msg = "working network transmission multiplier incorrectly set")  
+        np.testing.assert_approx_equal(primary_network.transmission_multiplier_type(), occupation_mult,
+                                       err_msg = "primary network transmission multiplier incorrectly set")        
+        np.testing.assert_approx_equal(random_network.transmission_multiplier_type(), random_mult,
+                                       err_msg = "random network transmission multiplier incorrectly set")  
+       
+        np.testing.assert_approx_equal(house_network.transmission_multiplier_combined(), house_mult * house_mult,
+                                       err_msg = "household network transmission multiplier incorrectly set")  
+        np.testing.assert_approx_equal(working_network.transmission_multiplier_combined(), occupation_mult * working_mult,
+                                       err_msg = "working network transmission multiplier incorrectly set")  
+        np.testing.assert_approx_equal(primary_network.transmission_multiplier_combined(), occupation_mult * primary_mult,
+                                       err_msg = "primary network transmission multiplier incorrectly set")        
+        np.testing.assert_approx_equal(random_network.transmission_multiplier_combined(), random_mult * random_mult,
+                                       err_msg = "random network transmission multiplier incorrectly set")  
+       
+        model.run( n_steps = 1, verbose = False )
+         
+        # turn on a lockdown and check the household multipler changes correctly
+        model.update_running_params( "lockdown_on", True )
+        lockdown_mult = params.get_param( "lockdown_house_interaction_multiplier" )
+        np.testing.assert_approx_equal(house_network.transmission_multiplier_combined(), house_mult * house_mult * lockdown_mult,
+                                       err_msg = "household network transmission multiplier incorrectly set")  
+        model.run( n_steps = 1, verbose = False )
+        
+        model.update_running_params( "lockdown_on", False )
+        np.testing.assert_approx_equal(house_network.transmission_multiplier_combined(), house_mult * house_mult,
+                                       err_msg = "household network transmission multiplier incorrectly set")  
+        
+        
+        
+        
+        
+                   

--- a/tests/testthat/test-Strains.R
+++ b/tests/testthat/test-Strains.R
@@ -1,0 +1,40 @@
+library(R6)
+library( OpenABMCovid19)
+library( testthat )
+library( data.table )
+
+test_that("test_multiple_strain_generation_time", {
+
+  sd_tol <- 3
+
+  base_params <-list(
+    n_total = 10000,
+    mean_infectious_period = 5.5,
+    infectious_rate = 3,
+    end_time = 50,
+    max_n_strains = 2,
+    n_seed_infection = 0
+  )
+  n_seed_infection <- 200
+  mean_infectious_period_1 <- 3.5
+
+  # create model and add strain
+  abm     <- Model.new( params = base_params)
+  strain1 <- abm$add_new_strain( mean_infectious_period = mean_infectious_period_1 )
+
+  # seed infection in both strains
+  inf_id <- sample( 1:base_params[["n_total"]], n_seed_infection * 2, replace = FALSE)
+  for( idx in 1:n_seed_infection ) {
+    abm$seed_infect_by_idx( inf_id[ idx ], strain_idx = 0 )
+    abm$seed_infect_by_idx( inf_id[ idx + n_seed_infection ], strain_idx = 1 )
+  }
+  abm$run( verbose = FALSE )
+
+  trans     <- as.data.table( abm$get_transmissions())
+  gen_times <- trans[ time_infected_source == 0 & time_infected > 0, .( generation_time = mean( time_infected ), N = .N ), by = "strain_idx" ][order(strain_idx)]
+  gen_times[ , tol := sd_tol / sqrt( N ) * abm$get_param( "sd_infectious_period")]
+  gen_times[ , target := c( base_params[[ "mean_infectious_period" ]], mean_infectious_period_1 )]
+
+  expect_lt( gen_times[ 1, abs( generation_time - target ) ], gen_times[ 1, tol ])
+  expect_lt( gen_times[ 2, abs( generation_time - target ) ], gen_times[ 2, tol ])
+} )


### PR DESCRIPTION
Allow variants to have different generation time distributions and dwell times in disease states

Remove network type infectious curve and combine the network type transmission multiplier with the network specific multipliers

Move the infectious curves to the strain structures